### PR TITLE
workflows: pull latest fixes from projects

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -6,6 +6,10 @@ on:
       - '**/Cargo.lock'
     branches-ignore:
       - '**.tmp'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
 
 jobs:
   audit_check:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,13 +14,19 @@ env:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable
           - beta
-          - nightly
-          - 1.46.0  # MSRV
+          - 1.47.0  # MSRV
+        experimental: [false]
+        include:
+          # Stop breakages in nightly to fail the workflow
+          - rust: nightly
+            experimental: true
 
     steps:
       - uses: actions/checkout@v2
@@ -46,12 +52,3 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-
-      # Clippy has its own workflow, so it's kept commented out here
-      # If you want to enable this, uncomment these lines below and
-      # add the clippy component above.
-      #
-      #- uses: actions-rs/cargo@v1
-      #  with:
-      #    command: clippy
-      #    args: -- -D warnings

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - '**.tmp'
+  pull_request:
 
 jobs:
   clippy_check:
@@ -15,8 +16,8 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
             # Note: some codegen tools actually format the code, so add rustfmt
+            toolchain: stable
             components: clippy, rustfmt
             override: true
 


### PR DESCRIPTION
- [x] Allow (securely) running CI jobs for PR's originating in forks.
- [x] Protect against breakages in nightly for:
      - clippy and rustfmt
      - CI builds (nightly builds are nice to have, not required)
