### PR TITLE
bors.toml: update required statuses

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 # Note: audit statuses are only triggered in specific cases, so can't use here
-status = ["ci (stable)", "ci (beta)", "clippy", "clippy_check"]
-pr_status = ["ci (stable)", "ci (beta)", "clippy", "clippy_check"]
+status = ["ci (stable, false)", "ci (beta, false)", "clippy_check"]
+pr_status = ["ci (stable, false)", "ci (beta, false)", "clippy_check"]
 delete_merged_branches = true
 use_codeowners = true
 use_squash_merge = false


### PR DESCRIPTION
After adding a new parameter to the CI job matrix, we need to update which statuses are required by bors.